### PR TITLE
Write log segments to disk

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,0 @@
-// sum of ASCII values for probable fiesta
-const PORT: u16 = 1475;
-
-// size of each segment (maximum number of keys)
-const SEGMENT_SIZE: usize = 1000;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ pub mod storage {
     pub mod tree;
     pub mod lsm;
     pub mod diskseg;
+    pub mod files;
 }
 
 pub mod tst {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,13 +18,21 @@ pub mod tst {
     pub mod tst_util;
 }
 
+const LOGGING: bool = false;
+
+pub fn log(msg: &str) {
+    if LOGGING {
+        println!("{}", msg);
+    }
+}
+
 fn main() {
     let k = "foo";
     let mut l = LsmTree::new("x");
 
     let result= l.write(k, "bar");
     if result {
-        if let Some(v) = l.get(k) {println!("Value for {} is {}", k, v)}
+        if let Some(v) = l.get(k) {log(&format!("Value for {} is {}", k, v))}
     }
 
     //let mux: Mutex<LogSegment<String>> = Mutex::new(LogSegment::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@ use storage::{lsm::LsmTree};
 
 pub mod kvpair;
 pub mod operators;
-pub mod config;
 
 pub mod storage {
     pub mod tree;
     pub mod lsm;
+    pub mod diskseg;
 }
 
 pub mod tst {
@@ -14,14 +14,14 @@ pub mod tst {
     // https://stackoverflow.com/questions/58935890/how-to-import-from-a-file-in-a-subfolder-of-src
     pub mod bst_test;
     pub mod lsm_test;
-    pub mod operators_test;
+    pub mod tst_util;
 }
 
 fn main() {
     let k = "foo";
-    let l = LsmTree::new("x");
+    let mut l = LsmTree::new("x");
 
-    let (l, result) = l.write(k, "bar");
+    let result= l.write(k, "bar");
     if result {
         if let Some(v) = l.get(k) {println!("Value for {} is {}", k, v)}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,4 +26,6 @@ fn main() {
     if result {
         if let Some(v) = l.get(k) {println!("Value for {} is {}", k, v)}
     }
+
+    //let mux: Mutex<LogSegment<String>> = Mutex::new(LogSegment::new());
 }

--- a/src/storage/diskseg.rs
+++ b/src/storage/diskseg.rs
@@ -1,0 +1,60 @@
+use std::{cmp::Ordering, fs::File};
+
+use self::DiskSegment::*;
+
+pub enum DiskSegment {
+    OpenSegment{path_s: String, file: File},
+    ClosedSegment{path_s: String},
+}
+
+impl Ord for DiskSegment
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let own_path = match self {
+            OpenSegment{path_s, file: _} => {path_s},
+            ClosedSegment{path_s} => {path_s}
+        };
+
+        let other_path = match other {
+            OpenSegment{path_s, file: _} => {path_s},
+            ClosedSegment{path_s} => {path_s}
+        };
+
+        own_path.cmp(&other_path)
+    }
+}
+
+impl Eq for DiskSegment {
+}
+
+impl PartialEq for DiskSegment {
+    fn eq(&self, other: &Self) -> bool {
+        let own_path = match self {
+            OpenSegment{path_s, file: _} => {path_s},
+            ClosedSegment{path_s} => {path_s}
+        };
+
+        let other_path = match other {
+            OpenSegment{path_s, file: _} => {path_s},
+            ClosedSegment{path_s} => {path_s}
+        };
+
+        own_path == other_path
+    }
+}
+
+impl PartialOrd for DiskSegment {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let own_path = match self {
+            OpenSegment{path_s, file: _} => {path_s},
+            ClosedSegment{path_s} => {path_s}
+        };
+
+        let other_path = match other {
+            OpenSegment{path_s, file: _} => {path_s},
+            ClosedSegment{path_s} => {path_s}
+        };
+
+        own_path.partial_cmp(&other_path)
+    }
+}

--- a/src/storage/diskseg.rs
+++ b/src/storage/diskseg.rs
@@ -2,22 +2,24 @@ use std::{cmp::Ordering, fs::File};
 
 use self::DiskSegment::*;
 
+use super::tree::LogSegment;
+
 pub enum DiskSegment {
-    OpenSegment{path_s: String, file: File},
-    ClosedSegment{path_s: String},
+    OpenSegment{path_s: String, file: File, tree: LogSegment<String>},
+    ClosedSegment{path_s: String, file: File},
 }
 
 impl Ord for DiskSegment
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         let own_path = match self {
-            OpenSegment{path_s, file: _} => {path_s},
-            ClosedSegment{path_s} => {path_s}
+            OpenSegment{path_s, file: _, tree: _} => {path_s},
+            ClosedSegment{path_s, file: _} => {path_s}
         };
 
         let other_path = match other {
-            OpenSegment{path_s, file: _} => {path_s},
-            ClosedSegment{path_s} => {path_s}
+            OpenSegment{path_s, file: _, tree: _} => {path_s},
+            ClosedSegment{path_s, file: _} => {path_s}
         };
 
         own_path.cmp(&other_path)
@@ -30,13 +32,13 @@ impl Eq for DiskSegment {
 impl PartialEq for DiskSegment {
     fn eq(&self, other: &Self) -> bool {
         let own_path = match self {
-            OpenSegment{path_s, file: _} => {path_s},
-            ClosedSegment{path_s} => {path_s}
+            OpenSegment{path_s, file: _, tree: _} => {path_s},
+            ClosedSegment{path_s, file: _} => {path_s}
         };
 
         let other_path = match other {
-            OpenSegment{path_s, file: _} => {path_s},
-            ClosedSegment{path_s} => {path_s}
+            OpenSegment{path_s, file: _, tree: _} => {path_s},
+            ClosedSegment{path_s, file: _} => {path_s}
         };
 
         own_path == other_path
@@ -46,13 +48,13 @@ impl PartialEq for DiskSegment {
 impl PartialOrd for DiskSegment {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let own_path = match self {
-            OpenSegment{path_s, file: _} => {path_s},
-            ClosedSegment{path_s} => {path_s}
+            OpenSegment{path_s, file: _, tree: _} => {path_s},
+            ClosedSegment{path_s, file: _} => {path_s}
         };
 
         let other_path = match other {
-            OpenSegment{path_s, file: _} => {path_s},
-            ClosedSegment{path_s} => {path_s}
+            OpenSegment{path_s, file: _, tree: _} => {path_s},
+            ClosedSegment{path_s, file: _} => {path_s}
         };
 
         own_path.partial_cmp(&other_path)

--- a/src/storage/diskseg.rs
+++ b/src/storage/diskseg.rs
@@ -9,20 +9,44 @@ pub enum DiskSegment {
     ClosedSegment{path_s: String, file: File},
 }
 
+impl DiskSegment {
+    pub fn value(&self) -> &str {
+        match self {
+            OpenSegment { path_s, file: _, tree: _ } => {
+                &path_s
+            }
+            ClosedSegment{path_s, file: _} => {
+                &path_s
+            }
+        }
+    }
+}
+
+pub fn extract_seg_id(path: String) -> i32 {
+    path.split('/').last().unwrap().split('.').next().unwrap().split('_').nth(1).unwrap().parse::<i32>().unwrap()
+}
+
+
 impl Ord for DiskSegment
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let own_path = match self {
+        let own_path_id = match self {
             OpenSegment{path_s, file: _, tree: _} => {path_s},
             ClosedSegment{path_s, file: _} => {path_s}
         };
+
+        let own_path = own_path_id.clone();
+        let own_path_id = extract_seg_id(own_path);
 
         let other_path = match other {
             OpenSegment{path_s, file: _, tree: _} => {path_s},
             ClosedSegment{path_s, file: _} => {path_s}
         };
 
-        own_path.cmp(&other_path)
+        let other_path = other_path.clone();
+        let other_path_id = extract_seg_id(other_path);
+
+        other_path_id.cmp(&own_path_id)
     }
 }
 
@@ -31,32 +55,44 @@ impl Eq for DiskSegment {
 
 impl PartialEq for DiskSegment {
     fn eq(&self, other: &Self) -> bool {
-        let own_path = match self {
+        let own_path_id = match self {
             OpenSegment{path_s, file: _, tree: _} => {path_s},
             ClosedSegment{path_s, file: _} => {path_s}
         };
+
+        let own_path = own_path_id.clone();
+        let own_path_id = extract_seg_id(own_path);
 
         let other_path = match other {
             OpenSegment{path_s, file: _, tree: _} => {path_s},
             ClosedSegment{path_s, file: _} => {path_s}
         };
 
-        own_path == other_path
+        let other_path = other_path.clone();
+        let other_path_id = extract_seg_id(other_path);
+
+        own_path_id == other_path_id
     }
 }
 
 impl PartialOrd for DiskSegment {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let own_path = match self {
+        let own_path_id = match self {
             OpenSegment{path_s, file: _, tree: _} => {path_s},
             ClosedSegment{path_s, file: _} => {path_s}
         };
+
+        let own_path = own_path_id.clone();
+        let own_path_id = extract_seg_id(own_path);
 
         let other_path = match other {
             OpenSegment{path_s, file: _, tree: _} => {path_s},
             ClosedSegment{path_s, file: _} => {path_s}
         };
 
-        own_path.partial_cmp(&other_path)
+        let other_path = other_path.clone();
+        let other_path_id = extract_seg_id(other_path);
+
+        other_path_id.partial_cmp(&own_path_id)
     }
 }

--- a/src/storage/files.rs
+++ b/src/storage/files.rs
@@ -1,0 +1,109 @@
+use std::{fs::{create_dir, read_dir, remove_file, metadata, OpenOptions, File, remove_dir}, path::{PathBuf, Path}, env::current_dir};
+use super::diskseg::DiskSegment::{self, *};
+
+pub const LOG_EXT: &str = "log";
+pub const DATA_EXT: &str = "data";
+
+pub fn get_wal(name: &str, create: bool) -> File {
+    // Check for existing log for this DB, then we are not creating new DB and should
+    // restore log to memory
+    let path_str = format!("{}.{}", name, LOG_EXT);
+    let log_file = Path::new(&path_str);
+    let full_file_path = get_lsmdir(name).join(log_file);
+    println!("{:?}", full_file_path.as_os_str());
+    if create {
+        OpenOptions::new().create(true).write(true).append(true).open(full_file_path).unwrap()
+    }
+    else {
+        OpenOptions::new().read(true).write(true).append(true).open(full_file_path).unwrap()
+    }
+}
+
+pub fn reclaim_segments(name: &str) -> Vec<DiskSegment> {
+    let mut old_segments: Vec<DiskSegment> = Vec::new();
+
+    let lsm_dir = get_lsmdir(name);
+
+    if lsm_dir.is_dir() {
+        for item in read_dir(lsm_dir).unwrap() {
+            let item = item.unwrap();
+            let path = item.path();
+            
+            if let Some(ext) = path.extension() {
+                let md = metadata(&path).unwrap();
+                if md.is_file() && ext.eq(DATA_EXT) {
+                    let segment = ClosedSegment{path_s: String::from(name)};
+                    match old_segments.binary_search(&segment) {
+                        // Place log segments in order by name
+                        // TODO: We need to probably extract the numeric ordering
+                        // from the data files to properly order this vector e.g.
+                        // currently foo_10.data would be before foo_9.data
+                        Err(pos) => old_segments.insert(pos, segment),
+                        _ => {},
+                    }
+                }
+            }
+        }
+    }
+    else {
+        // For new LSM, we should have created the LSM dir for the WAL already, panic if not
+        panic!("No LSM dir found for LSM {}!", name);
+    }
+    old_segments
+}
+
+/*
+Purge LSM directory: Delete LSM directory and all log segment/WAL files.
+Will panic if we try to purge the LSM directory for a non-existing LSM
+*/
+pub fn purge_lsm_dir(name: &str) {
+    let lsm_dir = get_lsmdir(name);
+
+    if lsm_dir.is_dir() {
+        for item in read_dir(lsm_dir.clone()).unwrap() {
+            let item = item.unwrap();
+            let path = item.path();
+            
+            let md = metadata(&path).unwrap();
+            if md.is_file() {
+                if let Err(e) = remove_file(path) {
+                    panic!("unable to delete existing LSM files with error {}", e);
+                }
+            }
+        }
+        if let Err(e) = remove_dir(lsm_dir) {
+            panic!("unable to delete existing LSM directory with error {}", e);
+        }
+    }
+}
+
+/*
+Create LSM Directory: Create a new LSM directory for the specified LSM.
+Will panic if attempt to create LSM directory already occupied by existing LSM
+*/
+pub fn create_lsm_dir(name: &str) -> Result<(), &'static str> {
+    let lsm_dir = get_lsmdir(name);
+
+    if !lsm_dir.is_dir() {
+        if let Err(e) = create_dir(lsm_dir) {
+            panic!("failed to create log segments directory {}, with error {}!", name, e);
+        }
+    }
+    else {
+        return Err("Attempting to create LSM directory for existing LSM");
+    }
+    Ok(())
+}
+
+pub fn lsm_exists(name: &str) -> bool {
+    let lsm_dir = get_lsmdir(name);
+    lsm_dir.is_dir()
+}
+
+pub fn get_lsmdir(name: &str) -> PathBuf {
+    get_currdir().join(Path::new(name))
+}
+
+pub fn get_currdir() -> PathBuf {
+    current_dir().expect("Unable to get cwd")
+}

--- a/src/storage/files.rs
+++ b/src/storage/files.rs
@@ -1,4 +1,6 @@
 use std::{fs::{create_dir, read_dir, remove_file, metadata, OpenOptions, File, remove_dir}, path::{PathBuf, Path}, env::current_dir};
+use crate::log;
+
 use super::diskseg::DiskSegment::{self, *};
 
 pub const LOG_EXT: &str = "log";
@@ -10,7 +12,7 @@ pub fn get_wal(name: &str, create: bool) -> File {
     let path_str = format!("{}.{}", name, LOG_EXT);
     let log_file = Path::new(&path_str);
     let full_file_path = get_lsmdir(name).join(log_file);
-    println!("{:?}", full_file_path.as_os_str());
+    log(&format!("{:?}", full_file_path.as_os_str()));
     if create {
         OpenOptions::new().create(true).write(true).append(true).open(full_file_path).unwrap()
     }
@@ -37,7 +39,7 @@ pub fn get_seg_path_s(name: &str, seg_num: usize) -> String {
 
 pub fn get_segment(name: &str, seg_num: usize, create: bool) -> File {
     let full_file_path = get_seg_path(name, seg_num);
-    println!("Creating segment file {:?}", full_file_path.as_os_str());
+    log(&format!("Creating segment file {:?}", full_file_path.as_os_str()));
     if create {
         OpenOptions::new().create(true).write(true).append(true).open(full_file_path).unwrap()
     }

--- a/src/storage/files.rs
+++ b/src/storage/files.rs
@@ -19,12 +19,24 @@ pub fn get_wal(name: &str, create: bool) -> File {
     }
 }
 
-pub fn get_segment(name: &str, seg_num: usize, create: bool) -> File {
+pub fn get_seg_path(name: &str, seg_num: usize) -> PathBuf {
     // Check for existing log for this DB, then we are not creating new DB and should
     // restore log to memory
     let path_str = format!("segment_{}.{}", seg_num, LOG_EXT);
     let seg_path = Path::new(&path_str);
-    let full_file_path = get_lsmdir(name).join(seg_path);
+    get_lsmdir(name).join(seg_path)
+}
+
+pub fn get_seg_path_s(name: &str, seg_num: usize) -> String {
+    // Check for existing log for this DB, then we are not creating new DB and should
+    // restore log to memory
+    let path_str = format!("segment_{}.{}", seg_num, LOG_EXT);
+    let seg_path = Path::new(&path_str);
+    get_lsmdir(name).join(seg_path).to_str().unwrap().to_string()
+}
+
+pub fn get_segment(name: &str, seg_num: usize, create: bool) -> File {
+    let full_file_path = get_seg_path(name, seg_num);
     println!("Creating segment file {:?}", full_file_path.as_os_str());
     if create {
         OpenOptions::new().create(true).write(true).append(true).open(full_file_path).unwrap()

--- a/src/storage/lsm.rs
+++ b/src/storage/lsm.rs
@@ -1,11 +1,17 @@
-use std::{io::{BufReader, Write, BufRead}, path::Path, fs::{remove_file, OpenOptions, File}};
+use std::{io::{BufReader, Write, BufRead}, path::{Path, PathBuf}, fs::{metadata, create_dir, read_dir, remove_file, OpenOptions, File, remove_dir}, env};
 use crate::storage::tree::*;
 use crate::kvpair::*;
+
+use crate::storage::diskseg::DiskSegment::{self, *};
+
+const LOG_EXT: &str = "log";
+const DATA_EXT: &str = "data";
 
 pub struct LsmTree {
     name: String,
     log_file: File,
-    tree: LogSegment<String>
+    tree: LogSegment<String>,
+    log_segments: Vec<DiskSegment>,
 }
 
 impl LsmTree {
@@ -17,33 +23,53 @@ impl LsmTree {
     pub fn new(name: &str) -> LsmTree {
         // Check for existing log for this DB, then we are not creating new DB and should
         // restore log to memory
-        let path_str = format!("{}.log", name);
+        let path_str = format!("{}.{}", name, LOG_EXT);
         let log_file = Path::new(&path_str);
         if Path::exists(log_file) {
             let existing_log = OpenOptions::new().read(true).write(true).append(true).open(log_file).unwrap();
-            let tree = LsmTree{name: name.to_string(), log_file: existing_log, tree: LogSegment::new()};
-            let (tree, restore_result) = tree.restore();
+            let mut tree = LsmTree{
+                name: name.to_string(), 
+                log_file: existing_log, 
+                tree: LogSegment::new(), 
+                log_segments: reclaim_segments(name)};
+            let restore_result = tree.restore();
             assert!(restore_result, "Failed to restore WAL!");
             return tree;
         }
-        LsmTree{name: name.to_string(), log_file: OpenOptions::new().create(true).write(true).append(true).open(log_file).unwrap(), tree: LogSegment::new()}
+        LsmTree{
+            name: name.to_string(), 
+            log_file: OpenOptions::new().create(true).write(true).append(true).open(log_file).unwrap(), 
+            tree: LogSegment::new(), 
+            log_segments: reclaim_segments(name)}
     }
 
     /*
     New Delete Existing: Creates DB from scratch, deleting any existing DB with this name
     */
-    pub fn new_delete_existing(name: &'static str) -> LsmTree {
+    pub fn new_delete_existing(name: &str) -> LsmTree {
         // Check for existing log for this DB, then we are not creating new DB and should
         // restore log to memory
         let path_str = format!("{}.log", name);
         let log_file = Path::new(&path_str);
+
         if Path::exists(log_file) {
-            match remove_file(log_file) {
-                Ok(()) => {},
-                Err(e) => panic!("unable to delete existing wal with error {}", e),
+            if let Err(e) = remove_file(log_file) {
+                panic!("unable to delete existing wal with error {}", e);
             }
         }
-        LsmTree{name: name.to_string(), log_file: OpenOptions::new().create(true).write(true).append(true).open(log_file).unwrap(), tree: LogSegment::new()}
+
+        let lsm_dir = get_lsmdir(name);
+        if lsm_dir.is_dir() {
+            if let Err(e) = remove_dir(lsm_dir) {
+                panic!("unable to delete existing log segment directory with error {}", e);
+            }
+        }
+        
+        LsmTree{
+            name: name.to_string(), 
+            log_file: OpenOptions::new().create(true).write(true).append(true).open(log_file).unwrap(), 
+            tree: LogSegment::new(),
+            log_segments: reclaim_segments(name)}
     }
 
     /*
@@ -62,10 +88,10 @@ impl LsmTree {
     to the latest start up. Consumes each entry of the WAL beyond the latest non-persisted log entry
     and builds a new in-memory log segment
     */
-    fn restore(mut self) -> (LsmTree, bool) {
-        // Restore moves ex
-        let new_handle = self.log_file.try_clone().unwrap();
-        let wal_contents = BufReader::new(self.log_file).lines();
+    fn restore(&mut self) -> bool {
+        // Clone WAL handle since we cannot move WAL behind ref to LSM
+        let restore_handle = self.log_file.try_clone().unwrap();
+        let wal_contents = BufReader::new(restore_handle).lines();
         for line in wal_contents {
             if let Ok(line) = line {
                 // WAL format is an append-only log of entries like below
@@ -75,27 +101,83 @@ impl LsmTree {
                 let tuple = (line.next().unwrap().into(), line.next().unwrap().into());
                 self.tree.insert(tuple);
             }
+            else {
+                panic!("unable to get entry from WAL for {}, terminating", self.name);
+            }
         }
-        self.log_file = new_handle;
-        (self, true)
+        true
+    }
+
+    /*
+    Get: Queries LSM for value for the given key, will traverse log segments in newest
+    to oldest fashion to preverse append-only deletion semantics
+    */
+    pub fn get(&self, key: &str) -> Option<&String> {
+        return self.tree.get(key.to_string());
     }
 
     /*
     Write: Appends a new entry to the latest log segment, after first preserving the
     operation to the WAL
     */
-    pub fn write(mut self, key: &str, value: &str) -> (LsmTree, bool) {
+    pub fn write(&mut self, key: &str, value: &str) -> bool {
         let kvp = KVPair::new(key.into(), value.into());
         match self.log(&kvp) {
             true => {
                 self.tree.insert((key.to_string(), value.to_string()));
-                (self, true)
+                true
             },
-            false => {(self, false)}
+            false => {false}
         }
     }
 
-    pub fn get(&self, key: &str) -> Option<&String> {
-        return self.tree.get(key.to_string());
+    /*
+    Total Segments: Gets the total number of log segments on disk
+    */
+    pub fn total_segments(&self) -> usize {
+        self.log_segments.len()
     }
+}
+
+fn reclaim_segments(name: &str) -> Vec<DiskSegment> {
+    let mut old_segments: Vec<DiskSegment> = Vec::new();
+
+    let lsm_dir = get_lsmdir(name);
+
+    if lsm_dir.is_dir() {
+        for item in read_dir(lsm_dir).unwrap() {
+            let item = item.unwrap();
+            let path = item.path();
+            
+            if let Some(ext) = path.extension() {
+                let md = metadata(&path).unwrap();
+                if md.is_file() && ext.eq(DATA_EXT) {
+                    let segment = ClosedSegment{path_s: String::from(name)};
+                    match old_segments.binary_search(&segment) {
+                        // Place log segments in order by name
+                        // TODO: We need to probably extract the numeric ordering
+                        // from the data files to properly order this vector e.g.
+                        // currently foo_10.data would be before foo_9.data
+                        Err(pos) => old_segments.insert(pos, segment),
+                        _ => {},
+                    }
+                }
+            }
+        }
+    }
+    else {
+        // For new LSM, we don't reclaim any segments, but instead create the segment directory
+        if let Err(e) = create_dir(lsm_dir) {
+            panic!("failed to create log segments directory {}!", name);
+        }
+    }
+    old_segments
+}
+
+fn get_lsmdir(name: &str) -> PathBuf {
+    get_currdir().join(Path::new(name))
+}
+
+fn get_currdir() -> PathBuf {
+    env::current_dir().expect("Unable to get cwd")
 }

--- a/src/storage/lsm.rs
+++ b/src/storage/lsm.rs
@@ -1,11 +1,8 @@
-use std::{io::{BufReader, Write, BufRead}, path::{Path, PathBuf}, fs::{metadata, create_dir, read_dir, remove_file, OpenOptions, File, remove_dir}, env};
+use std::{io::{BufReader, BufRead, Write}, fs::File};
 use crate::storage::tree::*;
 use crate::kvpair::*;
 
-use crate::storage::diskseg::DiskSegment::{self, *};
-
-const LOG_EXT: &str = "log";
-const DATA_EXT: &str = "data";
+use crate::storage::{diskseg::DiskSegment::{self}, files::*};
 
 pub struct LsmTree {
     name: String,
@@ -21,12 +18,9 @@ impl LsmTree {
     and restores from the pre-existing WAL.
     */
     pub fn new(name: &str) -> LsmTree {
-        // Check for existing log for this DB, then we are not creating new DB and should
-        // restore log to memory
-        let path_str = format!("{}.{}", name, LOG_EXT);
-        let log_file = Path::new(&path_str);
-        if Path::exists(log_file) {
-            let existing_log = OpenOptions::new().read(true).write(true).append(true).open(log_file).unwrap();
+
+        if lsm_exists(name) {
+            let existing_log = get_wal(name, false);
             let mut tree = LsmTree{
                 name: name.to_string(), 
                 log_file: existing_log, 
@@ -36,9 +30,16 @@ impl LsmTree {
             assert!(restore_result, "Failed to restore WAL!");
             return tree;
         }
+
+        // Note: we only create LSM directory when the LSM does not exist already, replacing 
+        // this elsewhere in this ctor e.g. prior to above case for existing LSM will cause panic
+        if let Err(e) = create_lsm_dir(name) {
+            panic!("{}", e);
+        }
+
         LsmTree{
             name: name.to_string(), 
-            log_file: OpenOptions::new().create(true).write(true).append(true).open(log_file).unwrap(), 
+            log_file: get_wal(name, true), 
             tree: LogSegment::new(), 
             log_segments: reclaim_segments(name)}
     }
@@ -47,29 +48,13 @@ impl LsmTree {
     New Delete Existing: Creates DB from scratch, deleting any existing DB with this name
     */
     pub fn new_delete_existing(name: &str) -> LsmTree {
-        // Check for existing log for this DB, then we are not creating new DB and should
-        // restore log to memory
-        let path_str = format!("{}.log", name);
-        let log_file = Path::new(&path_str);
+        // Note: we only purge LSM directory because we are creating an LSM and deleting the
+        // existing LSM of this name, should not purge elsewhere
+        purge_lsm_dir(name);
 
-        if Path::exists(log_file) {
-            if let Err(e) = remove_file(log_file) {
-                panic!("unable to delete existing wal with error {}", e);
-            }
-        }
-
-        let lsm_dir = get_lsmdir(name);
-        if lsm_dir.is_dir() {
-            if let Err(e) = remove_dir(lsm_dir) {
-                panic!("unable to delete existing log segment directory with error {}", e);
-            }
-        }
-        
-        LsmTree{
-            name: name.to_string(), 
-            log_file: OpenOptions::new().create(true).write(true).append(true).open(log_file).unwrap(), 
-            tree: LogSegment::new(),
-            log_segments: reclaim_segments(name)}
+        // Once we have purged the existing LSM directory, this ctor operates
+        // the same as the default ctor
+        LsmTree::new(name)
     }
 
     /*
@@ -137,47 +122,4 @@ impl LsmTree {
     pub fn total_segments(&self) -> usize {
         self.log_segments.len()
     }
-}
-
-fn reclaim_segments(name: &str) -> Vec<DiskSegment> {
-    let mut old_segments: Vec<DiskSegment> = Vec::new();
-
-    let lsm_dir = get_lsmdir(name);
-
-    if lsm_dir.is_dir() {
-        for item in read_dir(lsm_dir).unwrap() {
-            let item = item.unwrap();
-            let path = item.path();
-            
-            if let Some(ext) = path.extension() {
-                let md = metadata(&path).unwrap();
-                if md.is_file() && ext.eq(DATA_EXT) {
-                    let segment = ClosedSegment{path_s: String::from(name)};
-                    match old_segments.binary_search(&segment) {
-                        // Place log segments in order by name
-                        // TODO: We need to probably extract the numeric ordering
-                        // from the data files to properly order this vector e.g.
-                        // currently foo_10.data would be before foo_9.data
-                        Err(pos) => old_segments.insert(pos, segment),
-                        _ => {},
-                    }
-                }
-            }
-        }
-    }
-    else {
-        // For new LSM, we don't reclaim any segments, but instead create the segment directory
-        if let Err(e) = create_dir(lsm_dir) {
-            panic!("failed to create log segments directory {}!", name);
-        }
-    }
-    old_segments
-}
-
-fn get_lsmdir(name: &str) -> PathBuf {
-    get_currdir().join(Path::new(name))
-}
-
-fn get_currdir() -> PathBuf {
-    env::current_dir().expect("Unable to get cwd")
 }

--- a/src/storage/tree.rs
+++ b/src/storage/tree.rs
@@ -4,12 +4,12 @@ use std::fs::File;
 use std::io::{Write};
 use crate::storage::tree::LogSegment::*;
 
-pub enum LogSegment<T: Ord + Debug + Display> {
+pub enum LogSegment<T: Ord + Clone + Debug + Display> {
     TreeNode{k: T, v: Option<T>, left: Box<LogSegment<T>>, right: Box<LogSegment<T>>},
     Nil
 }
 
-impl<T: Ord + Debug + Display> LogSegment<T> {
+impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
     pub fn new() -> LogSegment<T> {
         Nil
     }

--- a/src/storage/tree.rs
+++ b/src/storage/tree.rs
@@ -2,10 +2,21 @@ use std::fmt::{Debug, Display};
 use std::{cmp::*};
 use std::fs::File;
 use std::io::{Write};
+use crate::log;
 use crate::storage::tree::LogSegment::*;
 
+
+#[derive(Debug)]
+pub enum TriOption<T> {
+    TriSome(T),
+    TriNone,
+    Tombstoned
+}
+
+use self::TriOption::*;
+
 pub enum LogSegment<T: Ord + Clone + Debug + Display> {
-    TreeNode{k: T, v: Option<T>, left: Box<LogSegment<T>>, right: Box<LogSegment<T>>},
+    TreeNode{k: T, v: TriOption<T>, left: Box<LogSegment<T>>, right: Box<LogSegment<T>>},
     Nil
 }
 
@@ -17,11 +28,11 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
     pub fn insert(&mut self, pair: (T, T)) {
         match self {
             Nil => {
-                *self = TreeNode { k: pair.0, v: Some(pair.1), left: Box::new(Nil), right: Box::new(Nil) };
+                *self = TreeNode { k: pair.0, v: TriSome(pair.1), left: Box::new(Nil), right: Box::new(Nil) };
             },
             TreeNode{k, v, left, right} => {
                 match pair.0.cmp(k) {
-                    Ordering::Equal => *v = Some(pair.1),
+                    Ordering::Equal => *v = TriSome(pair.1),
                     Ordering::Greater => right.insert(pair),
                     Ordering::Less => left.insert(pair),
                 }
@@ -31,10 +42,12 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
 
     pub fn delete(&mut self, del_key: T) {
         match self {
-            Nil => {},
+            Nil => {
+                *self = TreeNode{k: del_key, v: Tombstoned, left: Box::new(Nil), right: Box::new(Nil)};
+            },
             TreeNode { k, v, left, right } => {
                 match del_key.cmp(k) {
-                    Ordering::Equal => *v = None,
+                    Ordering::Equal => *v = Tombstoned,
                     Ordering::Greater => right.delete(del_key),
                     Ordering::Less => left.delete(del_key)
                 }
@@ -42,12 +55,19 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
         }
     }
 
-    pub fn get(&self, get_key: T) -> Option<&T> {
+    pub fn get(&self, get_key: T) -> TriOption<&T> {
         match self {
-            Nil => {None},
+            Nil => TriNone,
             TreeNode { k, v, left, right } => {
                 match get_key.cmp(k) {
-                    Ordering::Equal => v.as_ref(),
+                    Ordering::Equal => {
+                        log(&format!("{} is {:?}", get_key, v));
+                        match v {
+                            TriNone => return TriNone,
+                            TriSome(v) => return TriSome(v),
+                            Tombstoned => return Tombstoned
+                        };
+                    }
                     Ordering::Greater => right.get(get_key),
                     Ordering::Less => left.get(get_key),
                 }
@@ -62,7 +82,7 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
             TreeNode { k, v, left, right } => {
                 left.write_to_disk(file);
 
-                if let Some(v) = v {
+                if let TriSome(v) = v {
                     if let Err(e) = file.write(format!("{} {}\n", k, v).as_bytes()) {
                         panic!("{}", e);
                     }
@@ -80,7 +100,7 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
 
     pub fn exists(&self, ex_key: T) -> bool {
         match self.get(ex_key) {
-            Some(_) => true,
+            TriSome(_) => true,
             _ => false
         }
     }
@@ -90,14 +110,8 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
             Nil => {
                 0
             }
-            TreeNode { k: _, v, left, right } => {
-                // Values are tombstoned in place rather than being deleted from
-                // the tree, so we need to check if there a valid sum type before
-                // we increment the size count
-                match v {
-                    Some(_) => {1 + left.size() + right.size()},
-                    None => {left.size() + right.size()}
-                }
+            TreeNode { k: _, v: _, left, right } => {
+                1 + left.size() + right.size()
             }
         }
     }

--- a/src/tst/bst_test.rs
+++ b/src/tst/bst_test.rs
@@ -28,9 +28,10 @@ pub fn test_bst_insert_delete() {
         assert!(tree.exists(first_ten_letters[i].to_string()), "The letter {} doesn't exist in the tree after insert", first_ten_letters[i]);
     }
 
+    let exp_size = tree.size();
+
     for i in 0..first_ten_letters.len() {
         tree.delete(first_ten_letters[i].to_string());
-        exp_size -= 1;
         assert!(tree.size() == exp_size, "Expected tree size {}, actually is {}", exp_size, tree.size());
         assert!(!tree.exists(first_ten_letters[i].to_string()), "The letter {} exists in the tree after delete", first_ten_letters[i]);
     }

--- a/src/tst/lsm_test.rs
+++ b/src/tst/lsm_test.rs
@@ -74,7 +74,7 @@ pub fn test_lsm_overwrite_value() {
 pub fn test_lsm_restore_from_log() {
     let mut lsm = LsmTree::new_delete_existing("test_lsm_restore_from_log");
 
-    for i in 0..6 {
+    for i in 0..lsm.num_entries() {
         let (k, v) = (format!("foo{}", i), format!("bar{}", i));
         lsm.write(&k, &v);
     }
@@ -84,7 +84,7 @@ pub fn test_lsm_restore_from_log() {
     // the existing lo (test_lsm_restore_from_log.log), rather than creating a fresh LSM
     let mut lsm = LsmTree::new("test_lsm_restore_from_log");
 
-    for i in 0..6 {
+    for i in 0..lsm.num_entries() {
         let (k, v) = (format!("foo{}", i), format!("bar{}", i));
         lsm.write(&k, &v);
         verify_key_value(&mut lsm, &k, &v);
@@ -100,8 +100,37 @@ pub fn test_lsm_get_tuples_from_old_segments() {
     to oldest order (with no duplicates in a segment), meaning the latest value for a particular key
     is what is respected, as opposed values for the same key in older segments
     */
-
     let mut lsm = LsmTree::new_delete_existing("test_lsm_get_tuples_from_old_segments");
+    let mut i = 0;
+
+    // Keep appending to the lsm until we persist the current log 
+    while lsm.total_segments() == 0 {
+        let (k, v) = (format!("foo{}", i), format!("bar{}", i));
+        lsm.write(&k, &v);
+        verify_key_value(&mut lsm, &k, &v);
+        i += 1;
+    }
+
+    let ex_segments = 1;
+    let ex_tree_size = 1;
+    assert!(lsm.total_segments() == ex_segments, "expected {} disk segments, actually {}", ex_segments, lsm.total_segments());
+    assert!(lsm.num_entries() == ex_tree_size, "expected {} entries in tree, actually {}", ex_tree_size, lsm.num_entries());
+
+    // Check all of the keys which are now in an old segment
+    for j in 0..i {
+        let (k, v) = (format!("foo{}", j), format!("bar{}", j));
+        verify_key_value(&mut lsm, &k, &v);
+    }
+}
+
+#[test]
+pub fn test_lsm_verify_reclaim_old_segments() {
+    /*
+    The goal of this test is to validate the enhancements made to persist full log segments to disk.
+    We would expect that any tuples that are updated reflect the value in the latest log segment,
+    and any prior values for the key are ignored
+    */
+    let mut lsm = LsmTree::new_delete_existing("test_lsm_verify_reclaim_old_segments");
     let mut i = 0;
 
     // Keep appending to the lsm until we persist the current log 
@@ -119,30 +148,86 @@ pub fn test_lsm_get_tuples_from_old_segments() {
 
     let mut i = 0;
 
-    let ex_segments = 1;
-    assert!(lsm.total_segments() == ex_segments, "expected {} disk segments, actually {}", ex_segments, lsm.total_segments());
+    // Replace all keys from above with new values
+    while lsm.total_segments() == 1 {
+        let (k, v) = (format!("foo{}", i), format!("zar{}", i));
+        lsm.write(&k, &v);
+        verify_key_value(&mut lsm, &k, &v);
+        i += 1;
+    }
 
-    // Check all of the keys which are now in an old segment
+    // We flush the in-memory segment lazily, so append one more key to force this
+    let (k, v) = (format!("foo{}", i), format!("zar{}", i));
+    lsm.write(&k, &v);
+    verify_key_value(&mut lsm, &k, &v);
+
+    let ex_segments = 2;
+    let ex_tree_size = 2;
+    assert!(lsm.total_segments() == ex_segments, "expected {} disk segments, actually {}", ex_segments, lsm.total_segments());
+    assert!(lsm.num_entries() == ex_tree_size, "expected {} entries in tree, actually {}", ex_tree_size, lsm.num_entries());
+
+    // First tree will have values foo0 to foo{tree size - 1}, second tree will
+    // have values foo{tree size} to foo{tree size - 2}, 
+    // in memory segment will have value foo{tree size - 1} and foo{tree size}
+    for j in 0..i {
+        let (k, v) = (format!("foo{}", j), format!("zar{}", j));
+        verify_key_value(&mut lsm, &k, &v);
+    }
+}
+/* 
+#[test]
+pub fn test_lsm_tombstone_existing_value() {
+    /*
+    The goal of this test is to validate the enhancements made to persist full log segments to disk.
+    We would expect that any tuples on an old log segment would be found were we to try to get these,
+    and also that we preserve the append-only log approach, where log segments are traversed in newest
+    to oldest order (with no duplicates in a segment), meaning the latest value for a particular key
+    is what is respected, as opposed values for the same key in older segments
+    */
+    let mut lsm = LsmTree::new_delete_existing("test_lsm_tombstone_existing_value");
+    let mut i = 0;
+
+    // Keep appending to the lsm until we persist the current log 
     while lsm.total_segments() == 0 {
         let (k, v) = (format!("foo{}", i), format!("bar{}", i));
+        lsm.write(&k, &v);
+        verify_key_value(&mut lsm, &k, &v);
+        i += 1;
+    }
+
+    // We flush the in-memory segment lazily, so append one more key to force this
+    let (k, v) = (format!("foo{}", i), format!("bar{}", i));
+    lsm.write(&k, &v);
+    verify_key_value(&mut lsm, &k, &v);
+
+    let mut i = 0;
+
+    // Replace all keys from above with new values
+    while lsm.total_segments() == 1 {
+        let (k, v) = (format!("foo{}", i), format!("zar{}", i));
+        lsm.write(&k, &v);
+        verify_key_value(&mut lsm, &k, &v);
+        i += 1;
+    }
+
+    // We flush the in-memory segment lazily, so append one more key to force this
+    let (k, v) = (format!("foo{}", i), format!("bar{}", i));
+    lsm.write(&k, &v);
+    verify_key_value(&mut lsm, &k, &v);
+
+    let mut i = 0;
+
+    let ex_segments = 2;
+    let ex_tree_size = 1;
+    assert!(lsm.total_segments() == ex_segments, "expected {} disk segments, actually {}", ex_segments, lsm.total_segments());
+    assert!(lsm.num_entries() == ex_tree_size, "expected {} entries in tree, actually {}", ex_tree_size, lsm.num_entries());
+
+    // Check all of the keys which are now in an old segment. Note we should prioritize
+    // the newest log segment when searching for the value (values of zar*)
+    while lsm.total_segments() == 0 {
+        let (k, v) = (format!("foo{}", i), format!("zar{}", i));
         verify_key_value(&mut lsm, &k, &v);
         i += 1;
     }
 }
-
-/* 
-
-#[test]
-pub fn test_lsm_verify_reclaim_old_segments() {
-    /*
-    The goal of this test is to verify, for an existing LSM which had previously persisted some log segments
-    to disk, that we reclaim all existing log segments on re-start
-    */
-
-    let lsm = LsmTree::new_delete_existing("test_lsm_verify_reclaim_old_segments");
-
-    // Keep appending to the lsm until we persist the current log segment
-    while lsm.total_segments() == 0 {
-
-    }
-} */
+*/

--- a/src/tst/lsm_test.rs
+++ b/src/tst/lsm_test.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 use crate::storage::lsm::LsmTree;
+
+#[allow(unused_imports)]
 use super::tst_util::verify_key_value;
 
 #[test]

--- a/src/tst/lsm_test.rs
+++ b/src/tst/lsm_test.rs
@@ -41,7 +41,7 @@ pub fn test_lsm_create_delete_existing() {
         panic!("Failed to get key value pair for key foo");
     }
 
-    let lsm_new_delete_existing = LsmTree::new_delete_existing(dbname);
+    let mut lsm_new_delete_existing = LsmTree::new_delete_existing(dbname);
 
     if let Some(_) = lsm_new_delete_existing.get("foo") {
         panic!("Failed to delete existing DB, found value for foo on new DB");
@@ -57,7 +57,7 @@ pub fn test_lsm_overwrite_value() {
     // write <foo, bar> to tree
     let result= lsm.write(k, v);
     if result {
-        verify_key_value(&lsm, k, v);
+        verify_key_value(&mut lsm, k, v);
     }
 
     // shadow v and replace original k-v pair
@@ -66,7 +66,7 @@ pub fn test_lsm_overwrite_value() {
     // write <foo, bar2> to tree, would expect to overwrite existing pair
     let result = lsm.write(k, v);
     if result {
-        verify_key_value(&lsm, k, v);
+        verify_key_value(&mut lsm, k, v);
     }
 }
 
@@ -87,10 +87,10 @@ pub fn test_lsm_restore_from_log() {
     for i in 0..6 {
         let (k, v) = (format!("foo{}", i), format!("bar{}", i));
         lsm.write(&k, &v);
-        verify_key_value(&lsm, &k, &v);
+        verify_key_value(&mut lsm, &k, &v);
     }
 }
-/*
+
 #[test]
 pub fn test_lsm_get_tuples_from_old_segments() {
     /*
@@ -108,16 +108,29 @@ pub fn test_lsm_get_tuples_from_old_segments() {
     while lsm.total_segments() == 0 {
         let (k, v) = (format!("foo{}", i), format!("bar{}", i));
         lsm.write(&k, &v);
-        verify_key_value(&lsm, &k, &v);
+        verify_key_value(&mut lsm, &k, &v);
         i += 1;
     }
 
     // We flush the in-memory segment lazily, so append one more key to force this
     let (k, v) = (format!("foo{}", i), format!("bar{}", i));
     lsm.write(&k, &v);
-    verify_key_value(&lsm, &k, &v);
-    
+    verify_key_value(&mut lsm, &k, &v);
+
+    let mut i = 0;
+
+    let ex_segments = 1;
+    assert!(lsm.total_segments() == ex_segments, "expected {} disk segments, actually {}", ex_segments, lsm.total_segments());
+
+    // Check all of the keys which are now in an old segment
+    while lsm.total_segments() == 0 {
+        let (k, v) = (format!("foo{}", i), format!("bar{}", i));
+        verify_key_value(&mut lsm, &k, &v);
+        i += 1;
+    }
 }
+
+/* 
 
 #[test]
 pub fn test_lsm_verify_reclaim_old_segments() {
@@ -132,4 +145,4 @@ pub fn test_lsm_verify_reclaim_old_segments() {
     while lsm.total_segments() == 0 {
 
     }
-}*/
+} */

--- a/src/tst/operators_test.rs
+++ b/src/tst/operators_test.rs
@@ -1,2 +1,0 @@
-#[cfg(test)]
-use crate::storage::lsm::LsmTree;

--- a/src/tst/tst_util.rs
+++ b/src/tst/tst_util.rs
@@ -1,10 +1,16 @@
-use crate::storage::lsm::LsmTree;
+use crate::{storage::lsm::LsmTree, log};
 pub fn verify_key_value(tree: &mut LsmTree, k: &str, v: &str) {
     if let Some(value) = tree.get(k) {
         assert!(v == value, "invalid key, expected {}, actually {}", v, value);
-        println!("verified {} {}", k, v);
+        log(&format!("verified {} {}", k, v));
     }
     else {
         panic!("No value found for key {}", k);
+    }
+}
+
+pub fn verify_deleted(tree: &mut LsmTree, k: &str) {
+    if let Some(value) = tree.get(k) {
+        panic!("expected deleted key {}, actually {}", k, value);
     }
 }

--- a/src/tst/tst_util.rs
+++ b/src/tst/tst_util.rs
@@ -1,0 +1,10 @@
+use crate::storage::lsm::LsmTree;
+pub fn verify_key_value(tree: &LsmTree, k: &str, v: &str) {
+    if let Some(value) = tree.get(k) {
+        println!("got value {} for key {}", value, k);
+        assert!(v == value, "invalid key, expected {}, actually {}", v, value);
+    }
+    else {
+        panic!("No value found for key {}", k);
+    }
+}

--- a/src/tst/tst_util.rs
+++ b/src/tst/tst_util.rs
@@ -1,5 +1,5 @@
 use crate::storage::lsm::LsmTree;
-pub fn verify_key_value(tree: &LsmTree, k: &str, v: &str) {
+pub fn verify_key_value(tree: &mut LsmTree, k: &str, v: &str) {
     if let Some(value) = tree.get(k) {
         println!("got value {} for key {}", value, k);
         assert!(v == value, "invalid key, expected {}, actually {}", v, value);

--- a/src/tst/tst_util.rs
+++ b/src/tst/tst_util.rs
@@ -1,8 +1,8 @@
 use crate::storage::lsm::LsmTree;
 pub fn verify_key_value(tree: &mut LsmTree, k: &str, v: &str) {
     if let Some(value) = tree.get(k) {
-        println!("got value {} for key {}", value, k);
         assert!(v == value, "invalid key, expected {}, actually {}", v, value);
+        println!("verified {} {}", k, v);
     }
     else {
         panic!("No value found for key {}", k);


### PR DESCRIPTION
added writing log segment to disk functionality. Tests include

1. writing the values in the in-memory tree to a disk segment (.log files)
2. reading log file to memory tree
2. verifying values on log segment are found
2. extends tree to have distinguishing ability between tomb stoned and non-existing keys, so deletes aren't ignored

separate change made unrelated to this issue was adding a LOGGING flag and wrapping println in a log function, to selectively enable/disable logging for debugging.