### PR TITLE
Log segment option

### DIFF
--- a/src/storage/tree.rs
+++ b/src/storage/tree.rs
@@ -66,10 +66,16 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
                         if let Some(right) = right {
                             right.delete(del_key);
                         }
+                        else {
+                            *right = Some(Box::new(TreeNode { k: del_key, v: Tombstoned, left: None, right: None }));
+                        }
                     },
                     Ordering::Less => {
                         if let Some(left) = left {
                             left.delete(del_key);
+                        }
+                        else {
+                            *left = Some(Box::new(TreeNode { k: del_key, v: Tombstoned, left: None, right: None }));
                         }
                     },
                 }

--- a/src/storage/tree.rs
+++ b/src/storage/tree.rs
@@ -16,7 +16,7 @@ pub enum TriOption<T> {
 use self::TriOption::*;
 
 pub enum LogSegment<T: Ord + Clone + Debug + Display> {
-    TreeNode{k: T, v: TriOption<T>, left: Box<LogSegment<T>>, right: Box<LogSegment<T>>},
+    TreeNode{k: T, v: TriOption<T>, left: Option<Box<LogSegment<T>>>, right: Option<Box<LogSegment<T>>>},
     Nil
 }
 
@@ -28,13 +28,27 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
     pub fn insert(&mut self, pair: (T, T)) {
         match self {
             Nil => {
-                *self = TreeNode { k: pair.0, v: TriSome(pair.1), left: Box::new(Nil), right: Box::new(Nil) };
+                *self = TreeNode { k: pair.0, v: TriSome(pair.1), left: None, right: None };
             },
             TreeNode{k, v, left, right} => {
                 match pair.0.cmp(k) {
                     Ordering::Equal => *v = TriSome(pair.1),
-                    Ordering::Greater => right.insert(pair),
-                    Ordering::Less => left.insert(pair),
+                    Ordering::Greater => {
+                        if let Some(right) = right {
+                            right.insert(pair);
+                        }
+                        else {
+                            *right = Some(Box::new(TreeNode { k: pair.0, v: TriSome(pair.1), left: None, right: None }));
+                        }
+                    },
+                    Ordering::Less => {
+                        if let Some(left) = left {
+                            left.insert(pair);
+                        }
+                        else {
+                            *left = Some(Box::new(TreeNode { k: pair.0, v: TriSome(pair.1), left: None, right: None }));
+                        }
+                    },
                 }
             }
         }
@@ -43,13 +57,21 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
     pub fn delete(&mut self, del_key: T) {
         match self {
             Nil => {
-                *self = TreeNode{k: del_key, v: Tombstoned, left: Box::new(Nil), right: Box::new(Nil)};
+                *self = TreeNode{k: del_key, v: Tombstoned, left: None, right: None};
             },
             TreeNode { k, v, left, right } => {
                 match del_key.cmp(k) {
                     Ordering::Equal => *v = Tombstoned,
-                    Ordering::Greater => right.delete(del_key),
-                    Ordering::Less => left.delete(del_key)
+                    Ordering::Greater => {
+                        if let Some(right) = right {
+                            right.delete(del_key);
+                        }
+                    },
+                    Ordering::Less => {
+                        if let Some(left) = left {
+                            left.delete(del_key);
+                        }
+                    },
                 }
             }
         }
@@ -68,8 +90,22 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
                             Tombstoned => return Tombstoned
                         };
                     }
-                    Ordering::Greater => right.get(get_key),
-                    Ordering::Less => left.get(get_key),
+                    Ordering::Greater => {
+                        if let Some(right) = right {
+                            return right.get(get_key);
+                        }
+                        else {
+                            return TriNone;
+                        }
+                    },
+                    Ordering::Less => {
+                        if let Some(left) = left {
+                            return left.get(get_key);
+                        }
+                        else {
+                            return TriNone;
+                        }
+                    },
                 }
             }
         }
@@ -80,7 +116,9 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
         match self {
             Nil => {},
             TreeNode { k, v, left, right } => {
-                left.write_to_disk(file);
+                if let Some(left) = left {
+                    left.write_to_disk(file);
+                }
 
                 if let TriSome(v) = v {
                     if let Err(e) = file.write(format!("{} {}\n", k, v).as_bytes()) {
@@ -93,7 +131,9 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
                         panic!("{}", e);
                     }
                 }
-                right.write_to_disk(file);
+                if let Some(right) = right {
+                    right.write_to_disk(file);
+                }
             }
         }
     }
@@ -111,7 +151,14 @@ impl<T: Ord + Clone + Debug + Display> LogSegment<T> {
                 0
             }
             TreeNode { k: _, v: _, left, right } => {
-                1 + left.size() + right.size()
+                let mut sum = 1;
+                if let Some (left) = left {
+                    sum += left.size();
+                }
+                if let Some(right) = right {
+                    sum += right.size();
+                }
+                sum
             }
         }
     }

--- a/src/tst/lsm_test.rs
+++ b/src/tst/lsm_test.rs
@@ -149,7 +149,7 @@ pub fn test_lsm_verify_reclaim_old_segments() {
     /*
     The goal of this test is to validate the enhancements made to persist full log segments to disk.
     We would expect that any tuples that are updated reflect the value in the latest log segment,
-    and any prior values for the key are ignored
+    and any prior values for the key     are ignored
     */
     let mut lsm = LsmTree::new_delete_existing("test_lsm_verify_reclaim_old_segments");
     let mut i = 0;


### PR DESCRIPTION
PR to close #7 . Wraps the left and right members of TreeNode in an option, minimize extra alloc on inserts to tree